### PR TITLE
Extend instructions and add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:22.10
+RUN apt-get update \
+    && apt-get install tesseract-ocr \
+    python3 \
+    python3-pip \
+	ghostscript \
+	pngquant \
+	unpaper \
+    -y \	
+    && apt-get clean \
+    && apt-get autoremove
+
+ADD . /home/App
+WORKDIR /home/App
+
+COPY requirements.txt ./
+
+RUN pip3  install --no-cache-dir -r requirements.txt
+RUN PATH=""
+COPY . .
+
+CMD [ "python3", "./main.py" ]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,42 @@
 # AIP Extractor
 
-i made something ugly.
+As the DFS now publishes the AIP-VFR online but each page only as an image and doesn't allow to print multiple pages, search the content and so on this tool scrapes the website and creates a nice PDF file.
 
-run `pip install -r requirements.txt` to install dependencies. tesseract also needs to be installed. then run `main.py`. this will scrape the DFS website, fetch all AIP VFR pages thate are provided as images (!), stick them together into PDF files and run OCR on it.
+## Features:
+- PDF creation: Pull the AIP-VFR and create one single PDF
+- OCR: Convert it from pictures to a PDF with searchable text
+- Docker: Optionally run the tool as a Docker container
+
+## Use standalone
+Install the requirements, these are: `python3 python3-pip Ghostscript Tesseract jbig2enc pngquant unpaper`
+As well as the python packages with `pip install -r requirements.txt` to install dependencies. Then run `main.py`. this will scrape the DFS website, fetch all AIP VFR pages thate are provided as images (!), stick them together into PDF files and run OCR on it.
 
 PDFs will be stored in the `output` folder.
 
-have fun.
+Example code on Ubuntu:
+```bash
+sudo apt install python3  python3-pip Ghostscript Tesseract, jbig2enc, pngquant, unpaper
+pip3 install -r requirements.txt
+mkdir output
+python3 main.py
+```
+
+## Docker container
+Clone project and cd into folder. Then build container.
+```bash
+cd aip-extract
+docker build -t aip-extract:latest .
+```
+Run the container once
+```bash
+docker run -it --rm -v "./output:/home/App/output" --name aip-extract aip-extract:latest
+```
+Or on Windows:
+```bash
+docker run -it --rm -v ".\output:/home/App/output" --name aip-extract aip-extract:latest
+```
+
+Please note that neither this repository nor the DockerHub image are actively managed. And sure, using ubuntu:22.10 results in a huge image, so I'm open for suggestions on that side.
+
+## Performance
+OCR processing runs on my personal machine at approx. 5 pages/second. The complete process for all ~1300 pages therefore takes about 20 to 30 minutes. As the script keeps most of the files in RAM one has to expect a high RAM usage as well as 100% CPU usage during the process.


### PR DESCRIPTION
Hello,
I extended the instructions in the Readme as I initially had some issues as some packages were missing. These are now included in the Readme.m.
Additionally I created a Dockerfile for everyone who would like to simply run it in Docker instead of installing the packages on the own machine. My Dockerfile is not really efficient but it does the job (Docker Image is around 1GB).