### PR TITLE
Make aip-extract work again

### DIFF
--- a/main.py
+++ b/main.py
@@ -11,7 +11,8 @@ BASE_URL = 'https://aip.dfs.de/basicVFR/'
 images = []
 
 def fetch_url(url):
-	response = requests.get(url)
+	session = requests.Session()
+	response = session.get(url)
 	# The AIP website sends us a misleading header `Content-Type: text/html`
 	# which results in the default ISO-8859-1 encoding. Hence we override
 	# encoding by an educated guess

--- a/main.py
+++ b/main.py
@@ -52,7 +52,16 @@ def generate_pdf(title):
 	global images
 	tmp = tempfile.NamedTemporaryFile(suffix='.pdf')
 	tmp.write(img2pdf.convert(images))
-	ocrmypdf.ocr(input_file=tmp.name, output_file=f'output/{title}.pdf')
+	ocrmypdf.ocr(
+		input_file=tmp.name,
+		output_file=f'output/{title}.pdf',
+		language=['eng', 'deu'],
+		output_type='pdf',
+		optimize=2,
+		title=title,
+		author='DFS Deutsche Flugsicherung GmbH',
+		progress_bar=False,
+	)
 	tmp.close()
 	images = []
 
@@ -60,4 +69,4 @@ def generate_pdf(title):
 _, url = fetch_url(BASE_URL)
 BASE_URL = url
 
-fetch_folder("AIP", BASE_URL)
+fetch_folder('AIP', BASE_URL)

--- a/main.py
+++ b/main.py
@@ -1,12 +1,9 @@
 #!/usr/bin/env python3
-import requests
-import re
-import os
-import io
-import ocrmypdf
 import base64
-import tempfile
 import img2pdf
+import ocrmypdf
+import requests
+import tempfile
 from bs4 import BeautifulSoup
 
 BASE_URL = 'https://aip.dfs.de/basicVFR/'

--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ def fetch_html(url):
 def fetch_folder(foldertitle, folderurl, depth = 0):
 	#print(folderurl)
 	html = fetch_html(folderurl)
-	items = html.main.find_all('a', class_=['folder-link', 'document-link'])
+	items = html.find_all('a', class_=['folder-link', 'document-link'])
 
 	for item in items:
 		if 'folder-link' in item['class']:
@@ -38,7 +38,7 @@ def fetch_folder(foldertitle, folderurl, depth = 0):
 			print(f'  {documenttitle}')
 			fetch_document(documenttitle, requests.compat.urljoin(BASE_URL, item.get('href')))
 
-		if depth == 0:
+		if depth == 0 and len(images) > 0:
 			generate_pdf(title.strip())
 
 def fetch_document(documenttitle, documenturl):
@@ -53,6 +53,7 @@ def generate_pdf(title):
 	global images
 	tmp = tempfile.NamedTemporaryFile(suffix='.pdf')
 	tmp.write(img2pdf.convert(images))
+	print(f'  -> Running OCR on {title}')
 	ocrmypdf.ocr(
 		input_file=tmp.name,
 		output_file=f'output/{title}.pdf',

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4
 lxml
 ocrmypdf
-Pillow
 requests
+img2pdf


### PR DESCRIPTION
It seems that the recent AIP website does not seem to work with this script. I've updated a few selectors to make it work again, and additionally improved some parts of the script:

- Faster HTTP connection through usage of a HTTP session
- Correct encoding (important for German names)
- img2pdf instead of PIL for a faster conversion and less memory usage
- Exception handling when a folder is empty or redirect (albeit this could be improved)
- Some ocrmypdf optimization flags

Feedback is welcome!