### PR TITLE
update Dockerfile with ubuntu:24.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,22 +1,22 @@
-FROM ubuntu:22.10
+FROM ubuntu:24.04
+
 RUN apt-get update \
-    && apt-get install tesseract-ocr \
-    python3 \
-    python3-pip \
-	ghostscript \
-	pngquant \
-	unpaper \
-    -y \	
-    && apt-get clean \
-    && apt-get autoremove
+    &&  apt-get install -y \
+        tesseract-ocr \
+        tesseract-ocr-deu \
+        python3 \
+        python3-pip \
+        ghostscript \
+        pngquant \
+        unpaper \
+        jbig2 \
+    &&  apt-get clean \
+    &&  apt-get autoremove
 
-ADD . /home/App
-WORKDIR /home/App
+WORKDIR /app
+COPY requirements.txt .
+RUN pip3 install --break-system-packages --no-cache-dir -r requirements.txt
 
-COPY requirements.txt ./
+COPY main.py .
 
-RUN pip3  install --no-cache-dir -r requirements.txt
-RUN PATH=""
-COPY . .
-
-CMD [ "python3", "./main.py" ]
+CMD [ "python3", "/app/main.py" ]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 As the DFS now publishes the AIP-VFR online but each page only as an image and doesn't allow to print multiple pages, search the content and so on this tool scrapes the website and creates a nice PDF file.
 
-## Features:
+## Features
 - PDF creation: Pull the AIP-VFR and create one single PDF
 - OCR: Convert it from pictures to a PDF with searchable text
 - Docker: Optionally run the tool as a Docker container
@@ -29,14 +29,14 @@ docker build -t aip-extract:latest .
 ```
 Run the container once
 ```bash
-docker run -it --rm -v "./output:/home/App/output" --name aip-extract aip-extract:latest
+docker run -it --rm -v "./output:/app/output" --name aip-extract aip-extract:latest
 ```
 Or on Windows:
 ```bash
-docker run -it --rm -v ".\output:/home/App/output" --name aip-extract aip-extract:latest
+docker run -it --rm -v ".\output:/app/output" --name aip-extract aip-extract:latest
 ```
 
-Please note that neither this repository nor the DockerHub image are actively managed. And sure, using ubuntu:22.10 results in a huge image, so I'm open for suggestions on that side.
+Please note that neither this repository nor the DockerHub image are actively managed. And sure, using ubuntu:24.04 results in a huge image, so I'm open for suggestions on that side.
 
 ## Performance
 OCR processing runs on my personal machine at approx. 5 pages/second. The complete process for all ~1300 pages therefore takes about 20 to 30 minutes. As the script keeps most of the files in RAM one has to expect a high RAM usage as well as 100% CPU usage during the process.


### PR DESCRIPTION
This updates the Dockerfile to use ubuntu:24.04 and other necessary changes:

jbig2 is installed to fix

> The program 'jbig2' could not be executed or was not found on your
> system PATH.  This program is recommended when using the --optimize {2,3} | --jbig2-lossy arguments,
> but not required, so we will proceed.  For best results, install the program.

tesseract-ocr-deu is installed to fix

> ocrmypdf.exceptions.MissingDependencyError: OCR engine does not have language data for the following requested languages:
> deu
> Please install the appropriate language data for your OCR engine.

--break-system-packages is set to allow to install into the system environment, otherwise pip exits with an error.
In this case, this is okay, since we don't care about the system python.

Other small changes are made to improve the Dockerfile and README and update deprecated commands/change commands to the recommended ones.